### PR TITLE
[WIP] Add support for floats and scientific notation

### DIFF
--- a/json.l
+++ b/json.l
@@ -40,7 +40,16 @@
             [(and (= "\\" R) (= "u" (car Value))) (let U (cut 5 'Value) (link (char (hex (pack (tail 4 U) ] # \uNNNN hex
             [(and (= "\\" R) (= "b" (car Value))) (pop 'Value) (link (char (hex "08") ] # \b backspace
             [(and (= "\\" R) (= "f" (car Value))) (pop 'Value) (link (char (hex "0C") ] # \f formfeed
+            [(and (= ":" R) (num? (format (car Value))) (find '((N) (sub? (lowc N) "eE.")) (head -1 Value))) (json-parse-number '+) ] # 1.2345e+32, 1.2345E32, 1.2345e-32
+            [(and (= ":" R) (= "-" (car Value)) (num? (format (cadr Value))) (find '((N) (sub? (lowc N) "eE.")) (head -1 Value))) (json-parse-number '-) ] # -1.23e+32
             (T (link R)) ]
+
+[de json-parse-number (Sign)
+  (ifn  (num? (format (car (tail 2 Value))))
+        (err-throw (text "Invalid JSON number '@1'", (head -1 Value)))
+        (link ":")
+        (let Num (pack "\"" (cut (- (length Value) 1) 'Value) "\"")
+          (link Num) ]
 
 [de json-count-brackets (Str)
   (let Json_stack NIL

--- a/module.l
+++ b/module.l
@@ -5,7 +5,7 @@
   ("source"     "https://github.com/aw/picolisp-json.git")
   ("author"     "Alexander Williams")
   ("license"    "MIT")
-  ("copyright"  "(c) 2017-2018 Alexander Williams, Unscramble <license@unscramble.jp>")
+  ("copyright"  "(c) 2015-2018 Alexander Williams, Unscramble <license@unscramble.jp>")
   ("install"    "make")
   ("requires"
     ("picolisp-unit"    "v2.1.0"        "https://github.com/aw/picolisp-unit.git") ]

--- a/test/test_json.l
+++ b/test/test_json.l
@@ -48,17 +48,33 @@
                   "Encode list into JSON string" ]
 
 [de test-decode-unicode ()
-  (assert-equal   '(("name" . "^H")) (decode "{\"name\":\"\\b\"}") "Ensure '\\b' backspace is decoded")
-  (assert-equal   '(("name" . "^L")) (decode "{\"name\":\"\\f\"}") "Ensure '\\f' formfeed is decoded")
-  (assert-equal   '(("name" . "^J")) (decode "{\"name\":\"\\n\"}") "Ensure '\\n' newline is decoded")
-  (assert-equal   '(("name" . "^M")) (decode "{\"name\":\"\\r\"}") "Ensure '\\r' carriage return is decoded")
-  (assert-equal   '(("name" . "^I")) (decode "{\"name\":\"\\t\"}") "Ensure '\\t' horizontal tab is decoded") ]
+  (assert-equal   '(("name" . "^H")) (decode "{\"name\":\"\\b\"}") "(unicode) Ensure '\\b' backspace is decoded")
+  (assert-equal   '(("name" . "^L")) (decode "{\"name\":\"\\f\"}") "(unicode) Ensure '\\f' formfeed is decoded")
+  (assert-equal   '(("name" . "^J")) (decode "{\"name\":\"\\n\"}") "(unicode) Ensure '\\n' newline is decoded")
+  (assert-equal   '(("name" . "^M")) (decode "{\"name\":\"\\r\"}") "(unicode) Ensure '\\r' carriage return is decoded")
+  (assert-equal   '(("name" . "^I")) (decode "{\"name\":\"\\t\"}") "(unicode) Ensure '\\t' horizontal tab is decoded") ]
 
 [de test-decode-002f ()
-  (assert-equal   '(("name" . "/")) (decode "{\"name\":\"\\u002F\"}") "Ensure '\\u002F' produces the same result: /")
-  (assert-equal   '(("name" . "/")) (decode "{\"name\":\"\\u002f\"}") "Ensure '\\u002f' produces the same result: /")
-  (assert-equal   '(("name" . "/")) (decode "{\"name\":\"\\/\"}") "Ensure '\\/' produces the same result: /")
-  (assert-equal   '(("name" . "/")) (decode "{\"name\":\"/\"}") "Ensure '/' produces the same result: /") ]
+  (assert-equal   '(("name" . "/")) (decode "{\"name\":\"\\u002F\"}") "(\\u002f) Ensure '\\u002F' produces the same result: /")
+  (assert-equal   '(("name" . "/")) (decode "{\"name\":\"\\u002f\"}") "(\\u002f) Ensure '\\u002f' produces the same result: /")
+  (assert-equal   '(("name" . "/")) (decode "{\"name\":\"\\/\"}") "(\\u002f) Ensure '\\/' produces the same result: /")
+  (assert-equal   '(("name" . "/")) (decode "{\"name\":\"/\"}") "(\\u002f) Ensure '/' produces the same result: /") ]
+
+[de test-decode-scientific ()
+  (assert-equal   (quote ("name" . `(intern (pack "1." 234)))) (decode "{\"name\":1.234}") "(scientific) Ensure '1.234' is decoded")
+  (assert-equal   '(("name" . 1.234e32)) (decode "{\"name\":1.234e32}") "(scientific) Ensure '1.234e32' is decoded")
+  (assert-equal   '(("name" . 1.234E32)) (decode "{\"name\":1.234E32}") "(scientific) Ensure '1.234E32' is decoded")
+  (assert-equal   '(("name" . 1.234e+32)) (decode "{\"name\":1.234e+32}") "(scientific) Ensure '1.234e+32' is decoded")
+  (assert-equal   '(("name" . 1.234e-32)) (decode "{\"name\":1.234e-32}") "(scientific) Ensure '1.234e-32' is decoded")
+  (assert-equal   '(("name" . 156.234e+32)) (decode "{\"name\":156.234e+32}") "(scientific) Ensure '156.234e+32' is decoded")
+  (assert-equal   '(("name" . "156.234")) (decode "{\"name\":156.234}") "(scientific) Ensure '156.234' is decoded")
+  (assert-equal   '(("name" . "-9876.543210")) (decode "{\"name\":-9876.543210}") "(scientific) Ensure '-9876.543210' is decoded")
+  (assert-equal   '(("name" . -9876.543210e+32)) (decode "{\"name\":-9876.543210e+32}") "(scientific) Ensure '-9876.543210e+32' is decoded")
+  (assert-nil     (decode "{\"name\":-1.23e}") "(scientific) Ensure '-1.23e' returns NIL")
+  (assert-nil     (decode "{\"name\":1.234e}") "(scientific) Ensure '1.234e' returns NIL")
+  (assert-nil     (decode "{\"name\":12234e}") "(scientific) Ensure '12234e' returns NIL")
+  (assert-nil     (decode "{\"name\":1.234-}") "(scientific) Ensure '1.234-' returns NIL")
+  (assert-nil     (decode "{\"name\":1.234+}") "(scientific) Ensure '1.234+' returns NIL") ]
 
 [execute
   '(test-decode-string)
@@ -89,4 +105,5 @@
   '(assert-equal   '(("name" T 1 2 -3)) (decode "{\"name\":[1,2,-3]}") "Array values can be negative numbers")
   '(assert-equal   "{\"name\":[1,2,-23]}" (encode (decode (encode (decode "{\"name\":[1,2,-23]}")))) "Yo Dawg, (encode (decode (encode (decode...")
   '(test-decode-unicode)
-  '(test-decode-002f) ]
+  '(test-decode-002f)
+  '(test-decode-scientific) ]


### PR DESCRIPTION
Adding full support for floats/scientific E-notation would render this library 100% compliant with the JSON spec.

Since PicoLisp, doesn't support floats, those values would be interpreted as transient symbols (strings). For the moment there is no plan for converting them back from String -> Float.