### PR TITLE
Optionally prevent duplicate Object keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.10.0 (TBD)
+
+  * Optionally prevent duplicate keys from being accepted with '*Json_prevent_duplicate_keys'
+
 ## 3.9.0 (2018-06-19)
 
   * Store JSON parsing error message in *Msg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.10.0 (TBD)
 
   * Optionally prevent duplicate keys from being accepted with '*Json_prevent_duplicate_keys'
+  * Remove optional 'Make' parameter for '(link-array)'
 
 ## 3.9.0 (2018-06-19)
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Only the following functions are exported publicly:
 
 ### Notes
 
+  * To disallow duplicate Object keys: `(on *Json_prevent_duplicate_keys)`. Default allows duplicate Object keys.
   * A successful result will return a list. Failures return `NIL` and print the error message to `STDERR` (standard error).
   * Keys are in `car`, values are in `cdr`.
   * When the 2nd item in the list is `T`, the rest of the list represents a JSON array.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Only the following functions are exported publicly:
 ### Notes
 
   * To disallow duplicate Object keys: `(on *Json_prevent_duplicate_keys)`. Default allows duplicate Object keys.
-  * A successful result will return a list. Failures return `NIL` and print the error message to `STDERR` (standard error).
+  * A successful result will return a list.
+  * Failures return `NIL`, store the error message in `*Msg`, and print the error message to `STDERR` (standard error).
   * Keys are in `car`, values are in `cdr`.
   * When the 2nd item in the list is `T`, the rest of the list represents a JSON array.
   * When the 2nd item in the list is a cons pair, it represents a JSON object.

--- a/json.l
+++ b/json.l
@@ -75,6 +75,8 @@
     (err-throw (text "Invalid Array value '@1', must be {' OR '[' OR ']' OR string OR number OR true OR false OR null", Value) ]
 
 [de json-object-check (Name)
+  (when (and *Json_prevent_duplicate_keys (assoc (pack Name) (made)))
+        (err-throw (text "Duplicate Object key '@1'", Name)) )
   (or
     (lst? Name)
     (= "}" Name)

--- a/json.l
+++ b/json.l
@@ -99,8 +99,7 @@
               (pop '*Json)
               (eval Linker) ]
 
-[de link-array (Make)
-  (when Make (link T))
+[de link-array ()
   (link-generic '(json-array-check Name)
                 '(link-array)
                 "]"
@@ -120,7 +119,7 @@
 [de iterate-object ()
   (let Type (pop '*Json)
     (cond
-      ((= "[" Type)     (make (link-array T)))
+      ((= "[" Type)     (make (link T) (link-array)))
       ((= "{" Type)     (make (link-object)))
       ((lst? Type)      (pack Type))
       ((num? Type)      Type)

--- a/test/test_json.l
+++ b/test/test_json.l
@@ -60,6 +60,12 @@
   (assert-equal   '(("name" . "/")) (decode "{\"name\":\"\\/\"}") "Ensure '\\/' produces the same result: /")
   (assert-equal   '(("name" . "/")) (decode "{\"name\":\"/\"}") "Ensure '/' produces the same result: /") ]
 
+[de test-duplicate-keys ()
+  (on *Json_prevent_duplicate_keys)
+  (assert-nil      (decode "{\"test\":true,\"test\":false}") "Duplicate keys are not allowed")
+  (off *Json_prevent_duplicate_keys)
+  (assert-equal   '(("test" . true) ("test" . false)) (decode "{\"test\":true,\"test\":false}") "Duplicate keys are allowed") ]
+
 [execute
   '(test-decode-string)
   '(test-decode-file)
@@ -90,4 +96,5 @@
   '(assert-equal   "{\"name\":[1,2,-23]}" (encode (decode (encode (decode "{\"name\":[1,2,-23]}")))) "Yo Dawg, (encode (decode (encode (decode...")
   '(test-decode-unicode)
   '(test-decode-002f)
-  '(assert-equal   (or (decode "{\"name\":invalid}") *Msg) "Invalid Object 'invalid', must be '[' OR '{' OR string OR number OR true OR false OR null" "Error message is stored in *Msg") ]
+  '(assert-equal   (or (decode "{\"name\":invalid}") *Msg) "Invalid Object 'invalid', must be '[' OR '{' OR string OR number OR true OR false OR null" "Error message is stored in *Msg")
+  '(test-duplicate-keys) ]


### PR DESCRIPTION
The decision was made to optionally set aglobal  variable which would disallow duplicate Object keys. In that case an error would be displayed (as any other parsing error), and `NIL` would be returned (JSON string decoding failure).

If the `*Json_prevent_duplicate_keys` is not set (default), it will allow duplicate Object keys as before. In no situation should one key overwrite another (as JavaScript does). That can lead to unexpected behaviour.