### PR TITLE
Fix the namespace issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ This library has been rewritten in pure PicoLisp and contains **no external depe
 
 # Usage
 
-> **Note:** Namespaces do not work with versions of PicoLisp `>= 17.3.4`, please set the environment variable `PIL_NAMESPACES=false` (this may change in the future).
-
 Only the following functions are exported publicly:
 
   * `(decode arg1 arg2)` parses a JSON string or file

--- a/json.l
+++ b/json.l
@@ -4,15 +4,18 @@
 #
 # Copyright (c) 2015-2018 Alexander Williams, Unscramble <license@unscramble.jp>
 
-(and symbols (not (= "false" (sys "PIL_NAMESPACES")))
+(unless (== 64 64) (from "####"))
+
   (symbols 'json 'pico)
 
-  (local MODULE_INFO *Msg err-throw)
-  (local json-parse-file json-parse-string json-parse-unicode json-count-brackets)
-  (local json-array-check json-object-check json-object-check-separator)
-  (local link-generic link-array link-object link-object-value)
-  (local iterate-object iterate-list make-null make-boolean make-json-number)
-  (local make-json-string make-json-array make-generic make-object make-array) )
+  (local) (MODULE_INFO *Msg err-throw json-parse-file json-parse-string
+  json-parse-unicode json-count-brackets json-array-check json-object-check
+  json-object-check-separator link-generic link-array link-object
+  link-object-value iterate-object iterate-list make-null make-boolean
+  make-json-number make-json-string make-json-array make-generic make-object
+  make-array)
+
+####
 
 (setq *Json_control_characters (extract '((N) (unless (member N '("^H" "^L" "^J" "^M" "^I")) N)) (mapcar char (range 1 31))))
 


### PR DESCRIPTION
In a recent conversation on the PicoLisp mailing list, Alex pointed out the [correct usage of "local"](https://www.mail-archive.com/picolisp@software-lab.de/msg08710.html). I've created a PR out of Alex's suggestion.